### PR TITLE
Archive closed channels

### DIFF
--- a/houseofmisfits/weeping_willow/modules/support/support_channel.py
+++ b/houseofmisfits/weeping_willow/modules/support/support_channel.py
@@ -126,9 +126,17 @@ class SupportChannel:
         return await self.channel.send(*args, **kwargs)
 
     async def archive(self):
+        await self.channel.set_permissions(self.user, send_messages=False, read_messages=True)
+        loop = asyncio.get_running_loop()
+        loop.call_later(1200, self._schedule_archive_channel)
+
+    def _schedule_archive_channel(self):
+        loop = asyncio.get_running_loop()
+        loop.create_task(self._move_to_archives())
+
+    async def _move_to_archives(self):
         category = await self.get_support_archive_category()
         await self.channel.edit(reason='Archiving support channel', category=category)
-        await self.channel.set_permissions(self.user, send_messages=False, read_messages=True)
 
     async def unarchive(self):
         category = await self.get_support_category()

--- a/houseofmisfits/weeping_willow/modules/support/support_channel.py
+++ b/houseofmisfits/weeping_willow/modules/support/support_channel.py
@@ -76,7 +76,7 @@ class SupportChannel:
         guild = await self.client.fetch_guild(guild_id)
         category = await self.get_support_category()
         overwrites = category.overwrites
-        overwrites[self.user] = discord.PermissionOverwrite(read_messages=True)
+        overwrites[self.user] = discord.PermissionOverwrite(read_messages=True, send_messages=True)
         try:
             channel = await guild.create_text_channel(
                 name="support-{}".format(self.user.name),
@@ -94,6 +94,12 @@ class SupportChannel:
         category_id = await self.client.get_config('support_category')
         if category_id is None:
             raise ValueError("support_category is not set")
+        return await self.client.fetch_channel(category_id)
+
+    async def get_support_archive_category(self) -> discord.CategoryChannel:
+        category_id = await self.client.get_config('support_archive_category')
+        if category_id is None:
+            raise ValueError("support_archive_category is not set")
         return await self.client.fetch_channel(category_id)
 
     async def set_support_channel_id(self, channel_id):
@@ -118,6 +124,16 @@ class SupportChannel:
 
     async def send(self, *args, **kwargs):
         return await self.channel.send(*args, **kwargs)
+
+    async def archive(self):
+        category = await self.get_support_archive_category()
+        await self.channel.edit(reason='Archiving support channel', category=category)
+        await self.channel.set_permissions(self.user, send_messages=False, read_messages=True)
+
+    async def unarchive(self):
+        category = await self.get_support_category()
+        await self.channel.edit(reason='Opening support channel', category=category)
+        await self.channel.set_permissions(self.user, send_messages=True, read_messages=True)
 
     @property
     def id(self):

--- a/houseofmisfits/weeping_willow/modules/support/support_module.py
+++ b/houseofmisfits/weeping_willow/modules/support/support_module.py
@@ -34,6 +34,7 @@ class SupportModule(Module):
     async def start_support_session(self, message):
         try:
             session = await SupportSession.for_user(message.author, self.client)
+            await session.channel.unarchive()
             if session.brand_new:
                 await session.channel.send(
                     "Hey there, <@{author.id}>, I see you need some support...".format(author=message.author)

--- a/houseofmisfits/weeping_willow/modules/support/support_module.py
+++ b/houseofmisfits/weeping_willow/modules/support/support_module.py
@@ -57,7 +57,7 @@ class SupportModule(Module):
                 session = await SupportSession.in_channel(channel)
                 await session.close()
                 return True
-            elif self.is_support(message.author):
+            elif await self.is_support(message.author):
                 session = await SupportSession.in_channel(channel)
                 await session.close()
                 return True
@@ -85,8 +85,8 @@ class SupportModule(Module):
         await msg.delete()
         return str(reaction.emoji) == '✅'
 
-    def is_support(self, user):
-        support_role = self.client.get_config('support_role_id')
+    async def is_support(self, user):
+        support_role = await self.client.get_config('support_role_id')
         for role in user.roles:
             if str(role.id) == support_role:
                 return True

--- a/houseofmisfits/weeping_willow/modules/support/support_session.py
+++ b/houseofmisfits/weeping_willow/modules/support/support_session.py
@@ -89,7 +89,8 @@ class SupportSession:
 
     async def close(self):
         await self.set_status(self.Status.CLOSED)
-        await self.channel.send('This session is now closed. Go away.')
+        await self.channel.archive()
+        await self.channel.send('This session is now closed. Insert helpful message here about being able to read messages')
 
     async def create_timestamp(self):
         return await self._get_value('session_create_ts')


### PR DESCRIPTION
I've set up the `support` command so that it automatically creates a channel and opens a "session."

In the backend, Weeping Willow tracks each session with a unique ID. Because of this, it's still important to have the functionality to "close" a session--we don't want people to have perpetually open support sessions. So when a session is closed, this branch currently removes the ability for the supportee to send messages to the channel, sends a message (which will be edited in the future) that the session is closed, and then waits 20 minutes to move it to the archived-support category.

Opening pull request into support-command branch before developing further to get the support team's opinion on this functionality.